### PR TITLE
Use cpphs for preprocessing

### DIFF
--- a/type-eq.cabal
+++ b/type-eq.cabal
@@ -68,6 +68,9 @@ library
         Type.Eq.Higher
         Type.Eq.Higher.Unsafe
 
+    ghc-options: -pgmPcpphs -optP--cpp
+    build-tools: cpphs
+
 -- DeriveDataTypeable and PolyKinds sadly don't mix
 --    if impl(ghc)
 --        cpp-options: -DHAVE_TYPEABLE


### PR DESCRIPTION
Fixes issue #1. The package didn't compile with the clang preprocessor (used in OS X Mavericks).
